### PR TITLE
Check whether point lies within circle rather than frame rectangle for touches

### DIFF
--- a/EFCircularSlider/EFCircularSlider.m
+++ b/EFCircularSlider/EFCircularSlider.m
@@ -153,6 +153,15 @@
     CGContextRestoreGState(ctx);
 }
 
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    CGPoint p1 = [self centerPoint];
+    CGPoint p2 = point;
+    CGFloat xDist = (p2.x - p1.x);
+    CGFloat yDist = (p2.y - p1.y);
+    double distance = sqrt((xDist * xDist) + (yDist * yDist));
+    return distance < radius + 11;
+}
+
 -(void) drawLabels:(CGContextRef)ctx {
     if(labelsEvenSpacing == nil || [labelsEvenSpacing count] == 0) {
         return;
@@ -230,11 +239,16 @@
 }
 
 -(void)moveHandle:(CGPoint)point {
-    CGPoint centerPoint = CGPointMake(self.frame.size.width/2, self.frame.size.height/2);
+    CGPoint centerPoint;
+    centerPoint = [self centerPoint];
     int currentAngle = floor(AngleFromNorth(centerPoint, point, NO));
     angle = 360 - 90 - currentAngle;
     _currentValue = [self valueFromAngle];
     [self setNeedsDisplay];
+}
+
+- (CGPoint)centerPoint {
+    return CGPointMake(self.frame.size.width/2, self.frame.size.height/2);
 }
 
 #pragma mark - helper functions


### PR DESCRIPTION
This is a fix for #13.

This pull request makes sure that sliders act correctly when placed closely together in a concentric arrangement, like on the time picker demo application.

The problem was that touches were being registered by the slider even though it was outside of the circle, yet within its frame rectangle.

By implementing a containment check inside `pointInside:withEvent:`, such touch events are not captured; Cocoa passes touch events DOWN view hierarchy to views that sit beneath the slider — which is another slider, in our case.

Subsequently `beginTrackingWithTouch:withEvent:` is only invoked for touches within the circle (with a fat-finger allowance of +11 points — seems to work alright!), which is what we want!
