### PR TITLE
Breaking a feedback loop, while setting currentValue property

### DIFF
--- a/EFCircularSlider/EFCircularSlider.h
+++ b/EFCircularSlider/EFCircularSlider.h
@@ -35,7 +35,12 @@ typedef NS_ENUM(NSInteger, EFHandleType) {
 @property (nonatomic, assign) NSInteger labelDisplacement;
 @property (nonatomic) BOOL snapToLabels;
 
-
+/**
+ Calling this method sets currentValue of `EFCircularSlider` without triggering UIControlEventValueChanged action.
+ 
+ @param currentValue value for `EFCircularSlider`
+ */
+-(void)setCurrentValueManually:(float)currentValue;
 
 -(void)setInnerMarkingLabels:(NSArray*)labels;
 

--- a/EFCircularSlider/EFCircularSlider.m
+++ b/EFCircularSlider/EFCircularSlider.m
@@ -80,7 +80,8 @@
     return self.frame.size.height/2 - _lineWidth/2 - ([self circleDiameter]-_lineWidth) - _lineRadiusDisplacement;
 }
 
-- (void)setCurrentValue:(float)currentValue {
+-(void)setCurrentValue:(float)currentValue withActions:(BOOL)actions
+{
     _currentValue=currentValue;
     
     if(_currentValue>_maximumValue) _currentValue=_maximumValue;
@@ -89,7 +90,21 @@
     angle = [self angleFromValue];
     [self setNeedsLayout];
     [self setNeedsDisplay];
-    [self sendActionsForControlEvents:UIControlEventValueChanged];
+    
+    if (actions)
+    {
+        [self sendActionsForControlEvents:UIControlEventValueChanged];
+    }
+}
+
+- (void)setCurrentValue:(float)currentValue
+{
+    [self setCurrentValue:currentValue withActions:YES];
+}
+
+-(void)setCurrentValueManually:(float)currentValue
+{
+    [self setCurrentValue:currentValue withActions:NO];
 }
 
 #pragma mark - drawing methods


### PR DESCRIPTION
Hello there! Let me explain a bit my use case scenario and the reason i'm sending this PR.

So basically i'm implementing audio player, that uses EFCircularSlider as a progress bar for the audio track. And i have basically two workflows:

1. User is able to move handle to change progress on the audio track, rewinding back and forward.
2. Progress for the audio track is updated automatically, while audio is playing.

To achieve first, i'm subscribing to UIControlEventValueChanged action, read EFCircularSlider currentValue and transfer it to my audio player. To achieve second, i have a timer, that fires every 0.1 seconds, that reads current progress of the audio track, and sets currentValue property on EFCircularSlider. 

These two things create a endless feedback loop with currentValue property. To break it, a made a method on EFCircularSlider, that set's currentValue property **without** sending UIControlEventValueChanged action. 