### PR TITLE
Add slide on touch 

### DIFF
--- a/EFCircularSlider/EFCircularSlider.h
+++ b/EFCircularSlider/EFCircularSlider.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, EFHandleType) {
 @property (nonatomic, strong) UIColor* labelColor;
 @property (nonatomic, assign) NSInteger labelDisplacement;
 @property (nonatomic) BOOL snapToLabels;
+@property (nonatomic) BOOL slideOnTouch;
 
 
 

--- a/EFCircularSlider/EFCircularSlider.m
+++ b/EFCircularSlider/EFCircularSlider.m
@@ -234,6 +234,10 @@
 
 -(void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event{
     [super endTrackingWithTouch:touch withEvent:event];
+
+    CGPoint lastPoint = [touch locationInView:self];
+    [self moveHandle:lastPoint];
+
     if(_snapToLabels && labelsEvenSpacing != nil) {
         CGFloat newAngle=0;
         float minDist = 360;

--- a/EFCircularSlider/EFCircularSlider.m
+++ b/EFCircularSlider/EFCircularSlider.m
@@ -43,6 +43,7 @@
     _handleType = EFSemiTransparentWhiteCircle;
     _labelColor = [UIColor redColor];
     _labelDisplacement = 2;
+    _slideOnTouch = NO;
     
     self.backgroundColor = [UIColor clearColor];
 }
@@ -235,8 +236,10 @@
 -(void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event{
     [super endTrackingWithTouch:touch withEvent:event];
 
-    CGPoint lastPoint = [touch locationInView:self];
-    [self moveHandle:lastPoint];
+    if (_slideOnTouch) {
+        CGPoint lastPoint = [touch locationInView:self];
+        [self moveHandle:lastPoint];
+    }
 
     if(_snapToLabels && labelsEvenSpacing != nil) {
         CGFloat newAngle=0;

--- a/ExampleProject/EFCircularSlider/EFSnapToLabelsViewController.m
+++ b/ExampleProject/EFCircularSlider/EFSnapToLabelsViewController.m
@@ -30,6 +30,7 @@
 	
     CGRect sliderFrame = CGRectMake(60, 150, 200, 200);
     EFCircularSlider* circularSlider = [[EFCircularSlider alloc] initWithFrame:sliderFrame];
+    circularSlider.slideOnTouch = YES;
     
     NSArray* labels = @[@"B", @"C", @"D", @"E", @"A"];
     [circularSlider setInnerMarkingLabels:labels];


### PR DESCRIPTION
This PR adds a new property to this component: `slideOnTouch`.

Now, if you set `slideOnTouch` to YES, then you can set `currentValue` of the slider when you touch some position, i.e. you don't need to necessarily drag the handle to the value.

![shopping_list1](https://cloud.githubusercontent.com/assets/884725/22851322/4219a972-f005-11e6-8d6b-8192815b48c5.gif)
